### PR TITLE
Improved log formatting

### DIFF
--- a/NuciLog.Core/LogMessageBuilder.cs
+++ b/NuciLog.Core/LogMessageBuilder.cs
@@ -55,6 +55,11 @@ namespace NuciLog.Core
         {
             List<LogInfo> processedLogInfos = new List<LogInfo>();
 
+            if (string.IsNullOrWhiteSpace(message) && !(ex is null))
+            {
+                message = "An exception has occurred";
+            }
+
             if (!(message is null))
             {
                 processedLogInfos.Add(new LogInfo(LogInfoKey.Message, message));

--- a/NuciLog.Core/LogMessageBuilder.cs
+++ b/NuciLog.Core/LogMessageBuilder.cs
@@ -81,7 +81,22 @@ namespace NuciLog.Core
                 .GroupBy(x => x.Key)
                 .Select(group => new LogInfo(
                     group.First().Key,
-                    string.Join(";", group.Select(x => x.Value))));
+                    string.Join(";", group.Select(x => GetProcessedLogInfoValue(x.Value)))));
+        }
+
+        static string GetProcessedLogInfoValue(string value)
+        {
+            if (value is null)
+            {
+                return "<NULL>";
+            }
+            
+            if (value == string.Empty)
+            {
+                return "<N/A>";
+            }
+
+            return value;
         }
     }
 }

--- a/NuciLog.Core/Logger.cs
+++ b/NuciLog.Core/Logger.cs
@@ -84,8 +84,7 @@ namespace NuciLog.Core
             => Verbose(operation, operationStatus, message, exception, details?.ToList());
         public void Verbose(Operation operation, OperationStatus operationStatus, string message, Exception exception, IEnumerable<LogInfo> details)
         {
-            string logMessage = LogMessageBuilder.Build(operation, operationStatus, message, exception, details);
-            WriteLog(LogLevel.Verbose, logMessage);
+            WriteLog(LogLevel.Verbose, () => LogMessageBuilder.Build(operation, operationStatus, message, exception, details));
         }
         public void Verbose(Operation operation, OperationStatus operationStatus, string message, Exception exception, IEnumerable<LogInfo> details, params LogInfo[] details2)
             => Verbose(operation, operationStatus, message, exception, details.Concat(details2));
@@ -156,8 +155,7 @@ namespace NuciLog.Core
             => Debug(operation, operationStatus, message, exception, details?.ToList());
         public void Debug(Operation operation, OperationStatus operationStatus, string message, Exception exception, IEnumerable<LogInfo> details)
         {
-            string logMessage = LogMessageBuilder.Build(operation, operationStatus, message, exception, details);
-            WriteLog(LogLevel.Debug, logMessage);
+            WriteLog(LogLevel.Debug, () => LogMessageBuilder.Build(operation, operationStatus, message, exception, details));
         }
         public void Debug(Operation operation, OperationStatus operationStatus, string message, Exception exception, IEnumerable<LogInfo> details, params LogInfo[] details2)
             => Debug(operation, operationStatus, message, exception, details.Concat(details2));
@@ -228,8 +226,7 @@ namespace NuciLog.Core
             => Info(operation, operationStatus, message, exception, details?.ToList());
         public void Info(Operation operation, OperationStatus operationStatus, string message, Exception exception, IEnumerable<LogInfo> details)
         {
-            string logMessage = LogMessageBuilder.Build(operation, operationStatus, message, exception, details);
-            WriteLog(LogLevel.Info, logMessage);
+            WriteLog(LogLevel.Info, () => LogMessageBuilder.Build(operation, operationStatus, message, exception, details));
         }
         public void Info(Operation operation, OperationStatus operationStatus, string message, Exception exception, IEnumerable<LogInfo> details, params LogInfo[] details2)
             => Info(operation, operationStatus, message, exception, details.Concat(details2));
@@ -300,8 +297,7 @@ namespace NuciLog.Core
             => Warn(operation, operationStatus, message, exception, details?.ToList());
         public void Warn(Operation operation, OperationStatus operationStatus, string message, Exception exception, IEnumerable<LogInfo> details)
         {
-            string logMessage = LogMessageBuilder.Build(operation, operationStatus, message, exception, details);
-            WriteLog(LogLevel.Warn, logMessage);
+            WriteLog(LogLevel.Warn, ()=> LogMessageBuilder.Build(operation, operationStatus, message, exception, details));
         }
         public void Warn(Operation operation, OperationStatus operationStatus, string message, Exception exception, IEnumerable<LogInfo> details, params LogInfo[] details2)
             => Warn(operation, operationStatus, message, exception, details.Concat(details2));
@@ -372,8 +368,7 @@ namespace NuciLog.Core
             => Error(operation, operationStatus, message, exception, details?.ToList());
         public void Error(Operation operation, OperationStatus operationStatus, string message, Exception exception, IEnumerable<LogInfo> details)
         {
-            string logMessage = LogMessageBuilder.Build(operation, operationStatus, message, exception, details);
-            WriteLog(LogLevel.Error, logMessage);
+            WriteLog(LogLevel.Error, () => LogMessageBuilder.Build(operation, operationStatus, message, exception, details));
         }
         public void Error(Operation operation, OperationStatus operationStatus, string message, Exception exception, IEnumerable<LogInfo> details, params LogInfo[] details2)
             => Error(operation, operationStatus, message, exception, details.Concat(details2));
@@ -444,12 +439,11 @@ namespace NuciLog.Core
             => Fatal(operation, operationStatus, message, exception, details?.ToList());
         public void Fatal(Operation operation, OperationStatus operationStatus, string message, Exception exception, IEnumerable<LogInfo> details)
         {
-            string logMessage = LogMessageBuilder.Build(operation, operationStatus, message, exception, details);
-            WriteLog(LogLevel.Fatal, logMessage);
+            WriteLog(LogLevel.Fatal, () => LogMessageBuilder.Build(operation, operationStatus, message, exception, details));
         }
         public void Fatal(Operation operation, OperationStatus operationStatus, string message, Exception exception, IEnumerable<LogInfo> details, params LogInfo[] details2)
             => Fatal(operation, operationStatus, message, exception, details.Concat(details2));
 
-        protected abstract void WriteLog(LogLevel level, string logMessage);
+        protected abstract void WriteLog(LogLevel level, Func<string> logMessage);
     }
 }

--- a/NuciLog.Core/NuciLog.Core.csproj
+++ b/NuciLog.Core/NuciLog.Core.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>NuciLog.Core</RootNamespace>
-    <Version>2.2.5</Version>
+    <Version>2.3.0</Version>
     <Description>NuciLog Core package</Description>
     <Authors>Horațiu Mlendea</Authors>
     <Copyright>Copyright 2019 © Horațiu Mlendea</Copyright>

--- a/NuciLog.Core/SeriLogger.cs
+++ b/NuciLog.Core/SeriLogger.cs
@@ -19,32 +19,32 @@ namespace NuciLog.Core
             base.SetSourceContext(type);
         }
 
-        protected override void WriteLog(LogLevel level, string logMessage)
+        protected override void WriteLog(LogLevel level, Func<string> logMessage)
         {
             switch (level)
             {
                 case LogLevel.Verbose:
-                    logger.Verbose(logMessage);
+                    logger.Verbose(logMessage());
                     break;
 
                 case LogLevel.Debug:
-                    logger.Debug(logMessage);
+                    logger.Debug(logMessage());
                     break;
 
                 case LogLevel.Info:
-                    logger.Information(logMessage);
+                    logger.Information(logMessage());
                     break;
 
                 case LogLevel.Warn:
-                    logger.Warning(logMessage);
+                    logger.Warning(logMessage());
                     break;
 
                 case LogLevel.Error:
-                    logger.Error(logMessage);
+                    logger.Error(logMessage());
                     break;
 
                 case LogLevel.Fatal:
-                    logger.Fatal(logMessage);
+                    logger.Fatal(logMessage());
                     break;
             }
         }

--- a/NuciLog.UnitTests/NuciLog.Core.UnitTests/Helpers/TestLogger.cs
+++ b/NuciLog.UnitTests/NuciLog.Core.UnitTests/Helpers/TestLogger.cs
@@ -12,10 +12,10 @@ namespace NuciLog.Core.UnitTests
 
         public LogLevel LastLogLevel { get; set; }
 
-        protected override void WriteLog(LogLevel level, string logMessage)
+        protected override void WriteLog(LogLevel level, Func<string> logMessage)
         {
             LastLogLevel = level;
-            LastLogLine = logMessage;
+            LastLogLine = logMessage();
         }
     }
 }

--- a/NuciLog.UnitTests/NuciLog.Core.UnitTests/LogMessageBuilderTests.cs
+++ b/NuciLog.UnitTests/NuciLog.Core.UnitTests/LogMessageBuilderTests.cs
@@ -39,6 +39,7 @@ namespace NuciLog.Core.UnitTests
 
             string expected =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()}," +
+                $"Message=An exception has occurred," +
                 $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
             string actual = LogMessageBuilder.Build(operation, status, null, ex, null);
 
@@ -70,6 +71,7 @@ namespace NuciLog.Core.UnitTests
 
             string expected =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()}," +
+                $"Message=An exception has occurred," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest," +
                 $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
             string actual = LogMessageBuilder.Build(operation, status, null, ex, details);

--- a/NuciLog.UnitTests/NuciLog.Core.UnitTests/LogMessageBuilderTests.cs
+++ b/NuciLog.UnitTests/NuciLog.Core.UnitTests/LogMessageBuilderTests.cs
@@ -40,7 +40,7 @@ namespace NuciLog.Core.UnitTests
             string expected =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()}," +
                 $"Message=An exception has occurred," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             string actual = LogMessageBuilder.Build(operation, status, null, ex, null);
 
             Assert.AreEqual(expected, actual);
@@ -73,7 +73,7 @@ namespace NuciLog.Core.UnitTests
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()}," +
                 $"Message=An exception has occurred," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             string actual = LogMessageBuilder.Build(operation, status, null, ex, details);
 
             Assert.AreEqual(expected, actual);
@@ -112,7 +112,7 @@ namespace NuciLog.Core.UnitTests
 
             string expected =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()},Message={message}," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             string actual = LogMessageBuilder.Build(operation, status, message, ex, null);
 
             Assert.AreEqual(expected, actual);
@@ -146,7 +146,7 @@ namespace NuciLog.Core.UnitTests
             string expected =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()},Message={message}," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             string actual = LogMessageBuilder.Build(operation, status, message, ex, details);
 
             Assert.AreEqual(expected, actual);

--- a/NuciLog.UnitTests/NuciLog.Core.UnitTests/LoggerTests1Verbose.cs
+++ b/NuciLog.UnitTests/NuciLog.Core.UnitTests/LoggerTests1Verbose.cs
@@ -37,7 +37,10 @@ namespace NuciLog.Core.UnitTests
             Operation operation = Operation.StartUp;
             Exception ex = new Exception();
 
-            string expectedLogLine = $"Operation={operation.Name},Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+            string expectedLogLine =
+                $"Operation={operation.Name}," +
+                $"Message=An exception has occurred," +
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
             
             logger.Verbose(operation, ex);
 
@@ -96,7 +99,9 @@ namespace NuciLog.Core.UnitTests
             LogInfo details = new LogInfo(TestLogInfoKey.TestKey, "teeest");
 
             string expectedLogLine =
-                $"Operation={operation.Name},{details.Key.Name}={details.Value}," +
+                $"Operation={operation.Name}," +
+                $"Message=An exception has occurred," +
+                $"{details.Key.Name}={details.Value}," +
                 $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
             
             logger.Verbose(operation, ex, details);
@@ -113,7 +118,9 @@ namespace NuciLog.Core.UnitTests
             IEnumerable<LogInfo> details = new List<LogInfo> { new LogInfo(TestLogInfoKey.TestKey, "teeest") };
 
             string expectedLogLine =
-                $"Operation={operation.Name},{TestLogInfoKey.TestKey.Name}=teeest," +
+                $"Operation={operation.Name}," +
+                $"Message=An exception has occurred," +
+                $"{TestLogInfoKey.TestKey.Name}=teeest," +
                 $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
             
             logger.Verbose(operation, ex, details);
@@ -131,7 +138,9 @@ namespace NuciLog.Core.UnitTests
             LogInfo details2 = new LogInfo(TestLogInfoKey.TestKey2, "teeest2");
 
             string expectedLogLine =
-                $"Operation={operation.Name},{TestLogInfoKey.TestKey.Name}=teeest,{TestLogInfoKey.TestKey2.Name}=teeest2," +
+                $"Operation={operation.Name}," +
+                $"Message=An exception has occurred," +
+                $"{TestLogInfoKey.TestKey.Name}=teeest,{TestLogInfoKey.TestKey2.Name}=teeest2," +
                 $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
             
             logger.Verbose(operation, ex, details, details2);
@@ -163,6 +172,7 @@ namespace NuciLog.Core.UnitTests
 
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()}," +
+                $"Message=An exception has occurred," +
                 $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
             
             logger.Verbose(operation, status, ex);
@@ -233,6 +243,7 @@ namespace NuciLog.Core.UnitTests
 
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()}," +
+                $"Message=An exception has occurred," +
                 $"{details.Key.Name}={details.Value}," +
                 $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
             
@@ -252,6 +263,7 @@ namespace NuciLog.Core.UnitTests
 
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()}," +
+                $"Message=An exception has occurred," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest," +
                 $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
             
@@ -272,6 +284,7 @@ namespace NuciLog.Core.UnitTests
 
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()}," +
+                $"Message=An exception has occurred," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest,{TestLogInfoKey.TestKey2.Name}=teeest2," +
                 $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
             

--- a/NuciLog.UnitTests/NuciLog.Core.UnitTests/LoggerTests1Verbose.cs
+++ b/NuciLog.UnitTests/NuciLog.Core.UnitTests/LoggerTests1Verbose.cs
@@ -40,7 +40,7 @@ namespace NuciLog.Core.UnitTests
             string expectedLogLine =
                 $"Operation={operation.Name}," +
                 $"Message=An exception has occurred," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Verbose(operation, ex);
 
@@ -102,7 +102,7 @@ namespace NuciLog.Core.UnitTests
                 $"Operation={operation.Name}," +
                 $"Message=An exception has occurred," +
                 $"{details.Key.Name}={details.Value}," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Verbose(operation, ex, details);
 
@@ -121,7 +121,7 @@ namespace NuciLog.Core.UnitTests
                 $"Operation={operation.Name}," +
                 $"Message=An exception has occurred," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Verbose(operation, ex, details);
 
@@ -141,7 +141,7 @@ namespace NuciLog.Core.UnitTests
                 $"Operation={operation.Name}," +
                 $"Message=An exception has occurred," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest,{TestLogInfoKey.TestKey2.Name}=teeest2," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Verbose(operation, ex, details, details2);
 
@@ -173,7 +173,7 @@ namespace NuciLog.Core.UnitTests
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()}," +
                 $"Message=An exception has occurred," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Verbose(operation, status, ex);
 
@@ -245,7 +245,7 @@ namespace NuciLog.Core.UnitTests
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()}," +
                 $"Message=An exception has occurred," +
                 $"{details.Key.Name}={details.Value}," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Verbose(operation, status, ex, details);
 
@@ -265,7 +265,7 @@ namespace NuciLog.Core.UnitTests
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()}," +
                 $"Message=An exception has occurred," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Verbose(operation, status, ex, details);
 
@@ -286,7 +286,7 @@ namespace NuciLog.Core.UnitTests
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()}," +
                 $"Message=An exception has occurred," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest,{TestLogInfoKey.TestKey2.Name}=teeest2," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Verbose(operation, status, ex, details, details2);
 
@@ -315,7 +315,7 @@ namespace NuciLog.Core.UnitTests
 
             string expectedLogLine =
                 $"Message={message}," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Verbose(message, ex);
 
@@ -346,7 +346,7 @@ namespace NuciLog.Core.UnitTests
 
             string expectedLogLine =
                 $"Operation={operation.Name},Message={message}," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Verbose(operation, null, message, ex);
 
@@ -417,7 +417,7 @@ namespace NuciLog.Core.UnitTests
             string expectedLogLine =
                 $"Operation={operation.Name},Message={message}," +
                 $"{details.Key.Name}={details.Value}," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Verbose(operation, null, message, ex, details);
 
@@ -436,7 +436,7 @@ namespace NuciLog.Core.UnitTests
             string expectedLogLine =
                 $"Operation={operation.Name},Message={message}," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Verbose(operation, null, message, ex, details);
 
@@ -456,7 +456,7 @@ namespace NuciLog.Core.UnitTests
             string expectedLogLine =
                 $"Operation={operation.Name},Message={message}," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest,{TestLogInfoKey.TestKey2.Name}=teeest2," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Verbose(operation, null, message, ex, details, details2);
 
@@ -489,7 +489,7 @@ namespace NuciLog.Core.UnitTests
 
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()},Message={message}," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Verbose(operation, status, message, ex);
 
@@ -564,7 +564,7 @@ namespace NuciLog.Core.UnitTests
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()},Message={message}," +
                 $"{details.Key.Name}={details.Value}," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Verbose(operation, status, message, ex, details);
 
@@ -584,7 +584,7 @@ namespace NuciLog.Core.UnitTests
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()},Message={message}," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Verbose(operation, status, message, ex, details);
 
@@ -605,7 +605,7 @@ namespace NuciLog.Core.UnitTests
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()},Message={message}," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest,{TestLogInfoKey.TestKey2.Name}=teeest2," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Verbose(operation, status, message, ex, details, details2);
 

--- a/NuciLog.UnitTests/NuciLog.Core.UnitTests/LoggerTests2Debug.cs
+++ b/NuciLog.UnitTests/NuciLog.Core.UnitTests/LoggerTests2Debug.cs
@@ -40,7 +40,7 @@ namespace NuciLog.Core.UnitTests
             string expectedLogLine =
                 $"Operation={operation.Name}," +
                 $"Message=An exception has occurred," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Debug(operation, ex);
 
@@ -102,7 +102,7 @@ namespace NuciLog.Core.UnitTests
                 $"Operation={operation.Name}," +
                 $"Message=An exception has occurred," +
                 $"{details.Key.Name}={details.Value}," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Debug(operation, ex, details);
 
@@ -121,7 +121,7 @@ namespace NuciLog.Core.UnitTests
                 $"Operation={operation.Name}," +
                 $"Message=An exception has occurred," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Debug(operation, ex, details);
 
@@ -141,7 +141,7 @@ namespace NuciLog.Core.UnitTests
                 $"Operation={operation.Name}," +
                 $"Message=An exception has occurred," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest,{TestLogInfoKey.TestKey2.Name}=teeest2," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Debug(operation, ex, details, details2);
 
@@ -173,7 +173,7 @@ namespace NuciLog.Core.UnitTests
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()}," +
                 $"Message=An exception has occurred," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Debug(operation, status, ex);
 
@@ -245,7 +245,7 @@ namespace NuciLog.Core.UnitTests
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()}," +
                 $"Message=An exception has occurred," +
                 $"{details.Key.Name}={details.Value}," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Debug(operation, status, ex, details);
 
@@ -265,7 +265,7 @@ namespace NuciLog.Core.UnitTests
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()}," +
                 $"Message=An exception has occurred," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Debug(operation, status, ex, details);
 
@@ -286,7 +286,7 @@ namespace NuciLog.Core.UnitTests
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()}," +
                 $"Message=An exception has occurred," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest,{TestLogInfoKey.TestKey2.Name}=teeest2," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Debug(operation, status, ex, details, details2);
 
@@ -315,7 +315,7 @@ namespace NuciLog.Core.UnitTests
 
             string expectedLogLine =
                 $"Message={message}," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Debug(message, ex);
 
@@ -346,7 +346,7 @@ namespace NuciLog.Core.UnitTests
 
             string expectedLogLine =
                 $"Operation={operation.Name},Message={message}," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Debug(operation, null, message, ex);
 
@@ -417,7 +417,7 @@ namespace NuciLog.Core.UnitTests
             string expectedLogLine =
                 $"Operation={operation.Name},Message={message}," +
                 $"{details.Key.Name}={details.Value}," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Debug(operation, null, message, ex, details);
 
@@ -436,7 +436,7 @@ namespace NuciLog.Core.UnitTests
             string expectedLogLine =
                 $"Operation={operation.Name},Message={message}," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Debug(operation, null, message, ex, details);
 
@@ -456,7 +456,7 @@ namespace NuciLog.Core.UnitTests
             string expectedLogLine =
                 $"Operation={operation.Name},Message={message}," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest,{TestLogInfoKey.TestKey2.Name}=teeest2," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Debug(operation, null, message, ex, details, details2);
 
@@ -489,7 +489,7 @@ namespace NuciLog.Core.UnitTests
 
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()},Message={message}," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Debug(operation, status, message, ex);
 
@@ -564,7 +564,7 @@ namespace NuciLog.Core.UnitTests
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()},Message={message}," +
                 $"{details.Key.Name}={details.Value}," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Debug(operation, status, message, ex, details);
 
@@ -584,7 +584,7 @@ namespace NuciLog.Core.UnitTests
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()},Message={message}," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Debug(operation, status, message, ex, details);
 
@@ -605,7 +605,7 @@ namespace NuciLog.Core.UnitTests
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()},Message={message}," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest,{TestLogInfoKey.TestKey2.Name}=teeest2," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Debug(operation, status, message, ex, details, details2);
 

--- a/NuciLog.UnitTests/NuciLog.Core.UnitTests/LoggerTests2Debug.cs
+++ b/NuciLog.UnitTests/NuciLog.Core.UnitTests/LoggerTests2Debug.cs
@@ -37,7 +37,10 @@ namespace NuciLog.Core.UnitTests
             Operation operation = Operation.StartUp;
             Exception ex = new Exception();
 
-            string expectedLogLine = $"Operation={operation.Name},Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+            string expectedLogLine =
+                $"Operation={operation.Name}," +
+                $"Message=An exception has occurred," +
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
             
             logger.Debug(operation, ex);
 
@@ -96,7 +99,9 @@ namespace NuciLog.Core.UnitTests
             LogInfo details = new LogInfo(TestLogInfoKey.TestKey, "teeest");
 
             string expectedLogLine =
-                $"Operation={operation.Name},{details.Key.Name}={details.Value}," +
+                $"Operation={operation.Name}," +
+                $"Message=An exception has occurred," +
+                $"{details.Key.Name}={details.Value}," +
                 $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
             
             logger.Debug(operation, ex, details);
@@ -113,7 +118,9 @@ namespace NuciLog.Core.UnitTests
             IEnumerable<LogInfo> details = new List<LogInfo> { new LogInfo(TestLogInfoKey.TestKey, "teeest") };
 
             string expectedLogLine =
-                $"Operation={operation.Name},{TestLogInfoKey.TestKey.Name}=teeest," +
+                $"Operation={operation.Name}," +
+                $"Message=An exception has occurred," +
+                $"{TestLogInfoKey.TestKey.Name}=teeest," +
                 $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
             
             logger.Debug(operation, ex, details);
@@ -131,7 +138,9 @@ namespace NuciLog.Core.UnitTests
             LogInfo details2 = new LogInfo(TestLogInfoKey.TestKey2, "teeest2");
 
             string expectedLogLine =
-                $"Operation={operation.Name},{TestLogInfoKey.TestKey.Name}=teeest,{TestLogInfoKey.TestKey2.Name}=teeest2," +
+                $"Operation={operation.Name}," +
+                $"Message=An exception has occurred," +
+                $"{TestLogInfoKey.TestKey.Name}=teeest,{TestLogInfoKey.TestKey2.Name}=teeest2," +
                 $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
             
             logger.Debug(operation, ex, details, details2);
@@ -163,6 +172,7 @@ namespace NuciLog.Core.UnitTests
 
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()}," +
+                $"Message=An exception has occurred," +
                 $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
             
             logger.Debug(operation, status, ex);
@@ -233,6 +243,7 @@ namespace NuciLog.Core.UnitTests
 
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()}," +
+                $"Message=An exception has occurred," +
                 $"{details.Key.Name}={details.Value}," +
                 $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
             
@@ -252,6 +263,7 @@ namespace NuciLog.Core.UnitTests
 
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()}," +
+                $"Message=An exception has occurred," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest," +
                 $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
             
@@ -272,6 +284,7 @@ namespace NuciLog.Core.UnitTests
 
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()}," +
+                $"Message=An exception has occurred," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest,{TestLogInfoKey.TestKey2.Name}=teeest2," +
                 $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
             

--- a/NuciLog.UnitTests/NuciLog.Core.UnitTests/LoggerTests3Info.cs
+++ b/NuciLog.UnitTests/NuciLog.Core.UnitTests/LoggerTests3Info.cs
@@ -40,7 +40,7 @@ namespace NuciLog.Core.UnitTests
             string expectedLogLine =
                 $"Operation={operation.Name}," +
                 $"Message=An exception has occurred," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Info(operation, ex);
 
@@ -102,7 +102,7 @@ namespace NuciLog.Core.UnitTests
                 $"Operation={operation.Name}," +
                 $"Message=An exception has occurred," +
                 $"{details.Key.Name}={details.Value}," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Info(operation, ex, details);
 
@@ -121,7 +121,7 @@ namespace NuciLog.Core.UnitTests
                 $"Operation={operation.Name}," +
                 $"Message=An exception has occurred," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Info(operation, ex, details);
 
@@ -141,7 +141,7 @@ namespace NuciLog.Core.UnitTests
                 $"Operation={operation.Name}," +
                 $"Message=An exception has occurred," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest,{TestLogInfoKey.TestKey2.Name}=teeest2," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Info(operation, ex, details, details2);
 
@@ -173,7 +173,7 @@ namespace NuciLog.Core.UnitTests
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()}," +
                 $"Message=An exception has occurred," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Info(operation, status, ex);
 
@@ -245,7 +245,7 @@ namespace NuciLog.Core.UnitTests
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()}," +
                 $"Message=An exception has occurred," +
                 $"{details.Key.Name}={details.Value}," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Info(operation, status, ex, details);
 
@@ -265,7 +265,7 @@ namespace NuciLog.Core.UnitTests
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()}," +
                 $"Message=An exception has occurred," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Info(operation, status, ex, details);
 
@@ -286,7 +286,7 @@ namespace NuciLog.Core.UnitTests
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()}," +
                 $"Message=An exception has occurred," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest,{TestLogInfoKey.TestKey2.Name}=teeest2," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Info(operation, status, ex, details, details2);
 
@@ -315,7 +315,7 @@ namespace NuciLog.Core.UnitTests
 
             string expectedLogLine =
                 $"Message={message}," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Info(message, ex);
 
@@ -346,7 +346,7 @@ namespace NuciLog.Core.UnitTests
 
             string expectedLogLine =
                 $"Operation={operation.Name},Message={message}," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Info(operation, null, message, ex);
 
@@ -417,7 +417,7 @@ namespace NuciLog.Core.UnitTests
             string expectedLogLine =
                 $"Operation={operation.Name},Message={message}," +
                 $"{details.Key.Name}={details.Value}," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Info(operation, null, message, ex, details);
 
@@ -436,7 +436,7 @@ namespace NuciLog.Core.UnitTests
             string expectedLogLine =
                 $"Operation={operation.Name},Message={message}," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Info(operation, null, message, ex, details);
 
@@ -456,7 +456,7 @@ namespace NuciLog.Core.UnitTests
             string expectedLogLine =
                 $"Operation={operation.Name},Message={message}," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest,{TestLogInfoKey.TestKey2.Name}=teeest2," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Info(operation, null, message, ex, details, details2);
 
@@ -489,7 +489,7 @@ namespace NuciLog.Core.UnitTests
 
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()},Message={message}," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Info(operation, status, message, ex);
 
@@ -564,7 +564,7 @@ namespace NuciLog.Core.UnitTests
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()},Message={message}," +
                 $"{details.Key.Name}={details.Value}," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Info(operation, status, message, ex, details);
 
@@ -584,7 +584,7 @@ namespace NuciLog.Core.UnitTests
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()},Message={message}," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Info(operation, status, message, ex, details);
 
@@ -605,7 +605,7 @@ namespace NuciLog.Core.UnitTests
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()},Message={message}," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest,{TestLogInfoKey.TestKey2.Name}=teeest2," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Info(operation, status, message, ex, details, details2);
 

--- a/NuciLog.UnitTests/NuciLog.Core.UnitTests/LoggerTests3Info.cs
+++ b/NuciLog.UnitTests/NuciLog.Core.UnitTests/LoggerTests3Info.cs
@@ -37,7 +37,10 @@ namespace NuciLog.Core.UnitTests
             Operation operation = Operation.StartUp;
             Exception ex = new Exception();
 
-            string expectedLogLine = $"Operation={operation.Name},Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+            string expectedLogLine =
+                $"Operation={operation.Name}," +
+                $"Message=An exception has occurred," +
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
             
             logger.Info(operation, ex);
 
@@ -96,7 +99,9 @@ namespace NuciLog.Core.UnitTests
             LogInfo details = new LogInfo(TestLogInfoKey.TestKey, "teeest");
 
             string expectedLogLine =
-                $"Operation={operation.Name},{details.Key.Name}={details.Value}," +
+                $"Operation={operation.Name}," +
+                $"Message=An exception has occurred," +
+                $"{details.Key.Name}={details.Value}," +
                 $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
             
             logger.Info(operation, ex, details);
@@ -113,7 +118,9 @@ namespace NuciLog.Core.UnitTests
             IEnumerable<LogInfo> details = new List<LogInfo> { new LogInfo(TestLogInfoKey.TestKey, "teeest") };
 
             string expectedLogLine =
-                $"Operation={operation.Name},{TestLogInfoKey.TestKey.Name}=teeest," +
+                $"Operation={operation.Name}," +
+                $"Message=An exception has occurred," +
+                $"{TestLogInfoKey.TestKey.Name}=teeest," +
                 $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
             
             logger.Info(operation, ex, details);
@@ -131,7 +138,9 @@ namespace NuciLog.Core.UnitTests
             LogInfo details2 = new LogInfo(TestLogInfoKey.TestKey2, "teeest2");
 
             string expectedLogLine =
-                $"Operation={operation.Name},{TestLogInfoKey.TestKey.Name}=teeest,{TestLogInfoKey.TestKey2.Name}=teeest2," +
+                $"Operation={operation.Name}," +
+                $"Message=An exception has occurred," +
+                $"{TestLogInfoKey.TestKey.Name}=teeest,{TestLogInfoKey.TestKey2.Name}=teeest2," +
                 $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
             
             logger.Info(operation, ex, details, details2);
@@ -163,6 +172,7 @@ namespace NuciLog.Core.UnitTests
 
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()}," +
+                $"Message=An exception has occurred," +
                 $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
             
             logger.Info(operation, status, ex);
@@ -233,6 +243,7 @@ namespace NuciLog.Core.UnitTests
 
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()}," +
+                $"Message=An exception has occurred," +
                 $"{details.Key.Name}={details.Value}," +
                 $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
             
@@ -252,6 +263,7 @@ namespace NuciLog.Core.UnitTests
 
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()}," +
+                $"Message=An exception has occurred," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest," +
                 $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
             
@@ -272,6 +284,7 @@ namespace NuciLog.Core.UnitTests
 
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()}," +
+                $"Message=An exception has occurred," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest,{TestLogInfoKey.TestKey2.Name}=teeest2," +
                 $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
             

--- a/NuciLog.UnitTests/NuciLog.Core.UnitTests/LoggerTests4Warn.cs
+++ b/NuciLog.UnitTests/NuciLog.Core.UnitTests/LoggerTests4Warn.cs
@@ -40,7 +40,7 @@ namespace NuciLog.Core.UnitTests
             string expectedLogLine =
                 $"Operation={operation.Name}," +
                 $"Message=An exception has occurred," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Warn(operation, ex);
 
@@ -102,7 +102,7 @@ namespace NuciLog.Core.UnitTests
                 $"Operation={operation.Name}," +
                 $"Message=An exception has occurred," +
                 $"{details.Key.Name}={details.Value}," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Warn(operation, ex, details);
 
@@ -121,7 +121,7 @@ namespace NuciLog.Core.UnitTests
                 $"Operation={operation.Name}," +
                 $"Message=An exception has occurred," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Warn(operation, ex, details);
 
@@ -141,7 +141,7 @@ namespace NuciLog.Core.UnitTests
                 $"Operation={operation.Name}," +
                 $"Message=An exception has occurred," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest,{TestLogInfoKey.TestKey2.Name}=teeest2," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Warn(operation, ex, details, details2);
 
@@ -173,7 +173,7 @@ namespace NuciLog.Core.UnitTests
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()}," +
                 $"Message=An exception has occurred," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Warn(operation, status, ex);
 
@@ -245,7 +245,7 @@ namespace NuciLog.Core.UnitTests
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()}," +
                 $"Message=An exception has occurred," +
                 $"{details.Key.Name}={details.Value}," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Warn(operation, status, ex, details);
 
@@ -265,7 +265,7 @@ namespace NuciLog.Core.UnitTests
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()}," +
                 $"Message=An exception has occurred," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Warn(operation, status, ex, details);
 
@@ -286,7 +286,7 @@ namespace NuciLog.Core.UnitTests
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()}," +
                 $"Message=An exception has occurred," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest,{TestLogInfoKey.TestKey2.Name}=teeest2," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Warn(operation, status, ex, details, details2);
 
@@ -315,7 +315,7 @@ namespace NuciLog.Core.UnitTests
 
             string expectedLogLine =
                 $"Message={message}," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Warn(message, ex);
 
@@ -346,7 +346,7 @@ namespace NuciLog.Core.UnitTests
 
             string expectedLogLine =
                 $"Operation={operation.Name},Message={message}," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Warn(operation, null, message, ex);
 
@@ -417,7 +417,7 @@ namespace NuciLog.Core.UnitTests
             string expectedLogLine =
                 $"Operation={operation.Name},Message={message}," +
                 $"{details.Key.Name}={details.Value}," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Warn(operation, null, message, ex, details);
 
@@ -436,7 +436,7 @@ namespace NuciLog.Core.UnitTests
             string expectedLogLine =
                 $"Operation={operation.Name},Message={message}," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Warn(operation, null, message, ex, details);
 
@@ -456,7 +456,7 @@ namespace NuciLog.Core.UnitTests
             string expectedLogLine =
                 $"Operation={operation.Name},Message={message}," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest,{TestLogInfoKey.TestKey2.Name}=teeest2," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Warn(operation, null, message, ex, details, details2);
 
@@ -489,7 +489,7 @@ namespace NuciLog.Core.UnitTests
 
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()},Message={message}," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Warn(operation, status, message, ex);
 
@@ -564,7 +564,7 @@ namespace NuciLog.Core.UnitTests
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()},Message={message}," +
                 $"{details.Key.Name}={details.Value}," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Warn(operation, status, message, ex, details);
 
@@ -584,7 +584,7 @@ namespace NuciLog.Core.UnitTests
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()},Message={message}," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Warn(operation, status, message, ex, details);
 
@@ -605,7 +605,7 @@ namespace NuciLog.Core.UnitTests
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()},Message={message}," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest,{TestLogInfoKey.TestKey2.Name}=teeest2," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Warn(operation, status, message, ex, details, details2);
 

--- a/NuciLog.UnitTests/NuciLog.Core.UnitTests/LoggerTests4Warn.cs
+++ b/NuciLog.UnitTests/NuciLog.Core.UnitTests/LoggerTests4Warn.cs
@@ -37,7 +37,10 @@ namespace NuciLog.Core.UnitTests
             Operation operation = Operation.StartUp;
             Exception ex = new Exception();
 
-            string expectedLogLine = $"Operation={operation.Name},Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+            string expectedLogLine =
+                $"Operation={operation.Name}," +
+                $"Message=An exception has occurred," +
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
             
             logger.Warn(operation, ex);
 
@@ -96,7 +99,9 @@ namespace NuciLog.Core.UnitTests
             LogInfo details = new LogInfo(TestLogInfoKey.TestKey, "teeest");
 
             string expectedLogLine =
-                $"Operation={operation.Name},{details.Key.Name}={details.Value}," +
+                $"Operation={operation.Name}," +
+                $"Message=An exception has occurred," +
+                $"{details.Key.Name}={details.Value}," +
                 $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
             
             logger.Warn(operation, ex, details);
@@ -113,7 +118,9 @@ namespace NuciLog.Core.UnitTests
             IEnumerable<LogInfo> details = new List<LogInfo> { new LogInfo(TestLogInfoKey.TestKey, "teeest") };
 
             string expectedLogLine =
-                $"Operation={operation.Name},{TestLogInfoKey.TestKey.Name}=teeest," +
+                $"Operation={operation.Name}," +
+                $"Message=An exception has occurred," +
+                $"{TestLogInfoKey.TestKey.Name}=teeest," +
                 $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
             
             logger.Warn(operation, ex, details);
@@ -131,7 +138,9 @@ namespace NuciLog.Core.UnitTests
             LogInfo details2 = new LogInfo(TestLogInfoKey.TestKey2, "teeest2");
 
             string expectedLogLine =
-                $"Operation={operation.Name},{TestLogInfoKey.TestKey.Name}=teeest,{TestLogInfoKey.TestKey2.Name}=teeest2," +
+                $"Operation={operation.Name}," +
+                $"Message=An exception has occurred," +
+                $"{TestLogInfoKey.TestKey.Name}=teeest,{TestLogInfoKey.TestKey2.Name}=teeest2," +
                 $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
             
             logger.Warn(operation, ex, details, details2);
@@ -163,6 +172,7 @@ namespace NuciLog.Core.UnitTests
 
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()}," +
+                $"Message=An exception has occurred," +
                 $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
             
             logger.Warn(operation, status, ex);
@@ -233,6 +243,7 @@ namespace NuciLog.Core.UnitTests
 
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()}," +
+                $"Message=An exception has occurred," +
                 $"{details.Key.Name}={details.Value}," +
                 $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
             
@@ -252,6 +263,7 @@ namespace NuciLog.Core.UnitTests
 
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()}," +
+                $"Message=An exception has occurred," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest," +
                 $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
             
@@ -272,6 +284,7 @@ namespace NuciLog.Core.UnitTests
 
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()}," +
+                $"Message=An exception has occurred," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest,{TestLogInfoKey.TestKey2.Name}=teeest2," +
                 $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
             

--- a/NuciLog.UnitTests/NuciLog.Core.UnitTests/LoggerTests5Error.cs
+++ b/NuciLog.UnitTests/NuciLog.Core.UnitTests/LoggerTests5Error.cs
@@ -37,7 +37,10 @@ namespace NuciLog.Core.UnitTests
             Operation operation = Operation.StartUp;
             Exception ex = new Exception();
 
-            string expectedLogLine = $"Operation={operation.Name},Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+            string expectedLogLine =
+                $"Operation={operation.Name}," +
+                $"Message=An exception has occurred," +
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
             
             logger.Error(operation, ex);
 
@@ -96,7 +99,9 @@ namespace NuciLog.Core.UnitTests
             LogInfo details = new LogInfo(TestLogInfoKey.TestKey, "teeest");
 
             string expectedLogLine =
-                $"Operation={operation.Name},{details.Key.Name}={details.Value}," +
+                $"Operation={operation.Name}," +
+                $"Message=An exception has occurred," +
+                $"{details.Key.Name}={details.Value}," +
                 $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
             
             logger.Error(operation, ex, details);
@@ -113,7 +118,9 @@ namespace NuciLog.Core.UnitTests
             IEnumerable<LogInfo> details = new List<LogInfo> { new LogInfo(TestLogInfoKey.TestKey, "teeest") };
 
             string expectedLogLine =
-                $"Operation={operation.Name},{TestLogInfoKey.TestKey.Name}=teeest," +
+                $"Operation={operation.Name}," +
+                $"Message=An exception has occurred," +
+                $"{TestLogInfoKey.TestKey.Name}=teeest," +
                 $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
             
             logger.Error(operation, ex, details);
@@ -131,7 +138,9 @@ namespace NuciLog.Core.UnitTests
             LogInfo details2 = new LogInfo(TestLogInfoKey.TestKey2, "teeest2");
 
             string expectedLogLine =
-                $"Operation={operation.Name},{TestLogInfoKey.TestKey.Name}=teeest,{TestLogInfoKey.TestKey2.Name}=teeest2," +
+                $"Operation={operation.Name}," +
+                $"Message=An exception has occurred," +
+                $"{TestLogInfoKey.TestKey.Name}=teeest,{TestLogInfoKey.TestKey2.Name}=teeest2," +
                 $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
             
             logger.Error(operation, ex, details, details2);
@@ -163,6 +172,7 @@ namespace NuciLog.Core.UnitTests
 
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()}," +
+                $"Message=An exception has occurred," +
                 $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
             
             logger.Error(operation, status, ex);
@@ -233,6 +243,7 @@ namespace NuciLog.Core.UnitTests
 
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()}," +
+                $"Message=An exception has occurred," +
                 $"{details.Key.Name}={details.Value}," +
                 $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
             
@@ -252,6 +263,7 @@ namespace NuciLog.Core.UnitTests
 
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()}," +
+                $"Message=An exception has occurred," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest," +
                 $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
             
@@ -272,6 +284,7 @@ namespace NuciLog.Core.UnitTests
 
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()}," +
+                $"Message=An exception has occurred," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest,{TestLogInfoKey.TestKey2.Name}=teeest2," +
                 $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
             

--- a/NuciLog.UnitTests/NuciLog.Core.UnitTests/LoggerTests5Error.cs
+++ b/NuciLog.UnitTests/NuciLog.Core.UnitTests/LoggerTests5Error.cs
@@ -40,7 +40,7 @@ namespace NuciLog.Core.UnitTests
             string expectedLogLine =
                 $"Operation={operation.Name}," +
                 $"Message=An exception has occurred," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Error(operation, ex);
 
@@ -102,7 +102,7 @@ namespace NuciLog.Core.UnitTests
                 $"Operation={operation.Name}," +
                 $"Message=An exception has occurred," +
                 $"{details.Key.Name}={details.Value}," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Error(operation, ex, details);
 
@@ -121,7 +121,7 @@ namespace NuciLog.Core.UnitTests
                 $"Operation={operation.Name}," +
                 $"Message=An exception has occurred," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Error(operation, ex, details);
 
@@ -141,7 +141,7 @@ namespace NuciLog.Core.UnitTests
                 $"Operation={operation.Name}," +
                 $"Message=An exception has occurred," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest,{TestLogInfoKey.TestKey2.Name}=teeest2," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Error(operation, ex, details, details2);
 
@@ -173,7 +173,7 @@ namespace NuciLog.Core.UnitTests
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()}," +
                 $"Message=An exception has occurred," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Error(operation, status, ex);
 
@@ -245,7 +245,7 @@ namespace NuciLog.Core.UnitTests
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()}," +
                 $"Message=An exception has occurred," +
                 $"{details.Key.Name}={details.Value}," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Error(operation, status, ex, details);
 
@@ -265,7 +265,7 @@ namespace NuciLog.Core.UnitTests
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()}," +
                 $"Message=An exception has occurred," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Error(operation, status, ex, details);
 
@@ -286,7 +286,7 @@ namespace NuciLog.Core.UnitTests
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()}," +
                 $"Message=An exception has occurred," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest,{TestLogInfoKey.TestKey2.Name}=teeest2," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Error(operation, status, ex, details, details2);
 
@@ -315,7 +315,7 @@ namespace NuciLog.Core.UnitTests
 
             string expectedLogLine =
                 $"Message={message}," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Error(message, ex);
 
@@ -346,7 +346,7 @@ namespace NuciLog.Core.UnitTests
 
             string expectedLogLine =
                 $"Operation={operation.Name},Message={message}," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Error(operation, null, message, ex);
 
@@ -417,7 +417,7 @@ namespace NuciLog.Core.UnitTests
             string expectedLogLine =
                 $"Operation={operation.Name},Message={message}," +
                 $"{details.Key.Name}={details.Value}," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Error(operation, null, message, ex, details);
 
@@ -436,7 +436,7 @@ namespace NuciLog.Core.UnitTests
             string expectedLogLine =
                 $"Operation={operation.Name},Message={message}," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Error(operation, null, message, ex, details);
 
@@ -456,7 +456,7 @@ namespace NuciLog.Core.UnitTests
             string expectedLogLine =
                 $"Operation={operation.Name},Message={message}," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest,{TestLogInfoKey.TestKey2.Name}=teeest2," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Error(operation, null, message, ex, details, details2);
 
@@ -489,7 +489,7 @@ namespace NuciLog.Core.UnitTests
 
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()},Message={message}," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Error(operation, status, message, ex);
 
@@ -564,7 +564,7 @@ namespace NuciLog.Core.UnitTests
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()},Message={message}," +
                 $"{details.Key.Name}={details.Value}," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Error(operation, status, message, ex, details);
 
@@ -584,7 +584,7 @@ namespace NuciLog.Core.UnitTests
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()},Message={message}," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Error(operation, status, message, ex, details);
 
@@ -605,7 +605,7 @@ namespace NuciLog.Core.UnitTests
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()},Message={message}," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest,{TestLogInfoKey.TestKey2.Name}=teeest2," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Error(operation, status, message, ex, details, details2);
 

--- a/NuciLog.UnitTests/NuciLog.Core.UnitTests/LoggerTests6Fatal.cs
+++ b/NuciLog.UnitTests/NuciLog.Core.UnitTests/LoggerTests6Fatal.cs
@@ -37,7 +37,10 @@ namespace NuciLog.Core.UnitTests
             Operation operation = Operation.StartUp;
             Exception ex = new Exception();
 
-            string expectedLogLine = $"Operation={operation.Name},Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+            string expectedLogLine =
+                $"Operation={operation.Name}," +
+                $"Message=An exception has occurred," +
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
             
             logger.Fatal(operation, ex);
 
@@ -96,7 +99,9 @@ namespace NuciLog.Core.UnitTests
             LogInfo details = new LogInfo(TestLogInfoKey.TestKey, "teeest");
 
             string expectedLogLine =
-                $"Operation={operation.Name},{details.Key.Name}={details.Value}," +
+                $"Operation={operation.Name}," +
+                $"Message=An exception has occurred," +
+                $"{details.Key.Name}={details.Value}," +
                 $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
             
             logger.Fatal(operation, ex, details);
@@ -113,7 +118,9 @@ namespace NuciLog.Core.UnitTests
             IEnumerable<LogInfo> details = new List<LogInfo> { new LogInfo(TestLogInfoKey.TestKey, "teeest") };
 
             string expectedLogLine =
-                $"Operation={operation.Name},{TestLogInfoKey.TestKey.Name}=teeest," +
+                $"Operation={operation.Name}," +
+                $"Message=An exception has occurred," +
+                $"{TestLogInfoKey.TestKey.Name}=teeest," +
                 $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
             
             logger.Fatal(operation, ex, details);
@@ -131,7 +138,9 @@ namespace NuciLog.Core.UnitTests
             LogInfo details2 = new LogInfo(TestLogInfoKey.TestKey2, "teeest2");
 
             string expectedLogLine =
-                $"Operation={operation.Name},{TestLogInfoKey.TestKey.Name}=teeest,{TestLogInfoKey.TestKey2.Name}=teeest2," +
+                $"Operation={operation.Name}," +
+                $"Message=An exception has occurred," +
+                $"{TestLogInfoKey.TestKey.Name}=teeest,{TestLogInfoKey.TestKey2.Name}=teeest2," +
                 $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
             
             logger.Fatal(operation, ex, details, details2);
@@ -163,6 +172,7 @@ namespace NuciLog.Core.UnitTests
 
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()}," +
+                $"Message=An exception has occurred," +
                 $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
             
             logger.Fatal(operation, status, ex);
@@ -233,6 +243,7 @@ namespace NuciLog.Core.UnitTests
 
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()}," +
+                $"Message=An exception has occurred," +
                 $"{details.Key.Name}={details.Value}," +
                 $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
             
@@ -252,6 +263,7 @@ namespace NuciLog.Core.UnitTests
 
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()}," +
+                $"Message=An exception has occurred," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest," +
                 $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
             
@@ -272,6 +284,7 @@ namespace NuciLog.Core.UnitTests
 
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()}," +
+                $"Message=An exception has occurred," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest,{TestLogInfoKey.TestKey2.Name}=teeest2," +
                 $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
             

--- a/NuciLog.UnitTests/NuciLog.Core.UnitTests/LoggerTests6Fatal.cs
+++ b/NuciLog.UnitTests/NuciLog.Core.UnitTests/LoggerTests6Fatal.cs
@@ -40,7 +40,7 @@ namespace NuciLog.Core.UnitTests
             string expectedLogLine =
                 $"Operation={operation.Name}," +
                 $"Message=An exception has occurred," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Fatal(operation, ex);
 
@@ -102,7 +102,7 @@ namespace NuciLog.Core.UnitTests
                 $"Operation={operation.Name}," +
                 $"Message=An exception has occurred," +
                 $"{details.Key.Name}={details.Value}," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Fatal(operation, ex, details);
 
@@ -121,7 +121,7 @@ namespace NuciLog.Core.UnitTests
                 $"Operation={operation.Name}," +
                 $"Message=An exception has occurred," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Fatal(operation, ex, details);
 
@@ -141,7 +141,7 @@ namespace NuciLog.Core.UnitTests
                 $"Operation={operation.Name}," +
                 $"Message=An exception has occurred," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest,{TestLogInfoKey.TestKey2.Name}=teeest2," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Fatal(operation, ex, details, details2);
 
@@ -173,7 +173,7 @@ namespace NuciLog.Core.UnitTests
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()}," +
                 $"Message=An exception has occurred," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Fatal(operation, status, ex);
 
@@ -245,7 +245,7 @@ namespace NuciLog.Core.UnitTests
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()}," +
                 $"Message=An exception has occurred," +
                 $"{details.Key.Name}={details.Value}," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Fatal(operation, status, ex, details);
 
@@ -265,7 +265,7 @@ namespace NuciLog.Core.UnitTests
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()}," +
                 $"Message=An exception has occurred," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Fatal(operation, status, ex, details);
 
@@ -286,7 +286,7 @@ namespace NuciLog.Core.UnitTests
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()}," +
                 $"Message=An exception has occurred," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest,{TestLogInfoKey.TestKey2.Name}=teeest2," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Fatal(operation, status, ex, details, details2);
 
@@ -315,7 +315,7 @@ namespace NuciLog.Core.UnitTests
 
             string expectedLogLine =
                 $"Message={message}," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Fatal(message, ex);
 
@@ -346,7 +346,7 @@ namespace NuciLog.Core.UnitTests
 
             string expectedLogLine =
                 $"Operation={operation.Name},Message={message}," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Fatal(operation, null, message, ex);
 
@@ -417,7 +417,7 @@ namespace NuciLog.Core.UnitTests
             string expectedLogLine =
                 $"Operation={operation.Name},Message={message}," +
                 $"{details.Key.Name}={details.Value}," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Fatal(operation, null, message, ex, details);
 
@@ -436,7 +436,7 @@ namespace NuciLog.Core.UnitTests
             string expectedLogLine =
                 $"Operation={operation.Name},Message={message}," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Fatal(operation, null, message, ex, details);
 
@@ -456,7 +456,7 @@ namespace NuciLog.Core.UnitTests
             string expectedLogLine =
                 $"Operation={operation.Name},Message={message}," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest,{TestLogInfoKey.TestKey2.Name}=teeest2," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Fatal(operation, null, message, ex, details, details2);
 
@@ -489,7 +489,7 @@ namespace NuciLog.Core.UnitTests
 
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()},Message={message}," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Fatal(operation, status, message, ex);
 
@@ -564,7 +564,7 @@ namespace NuciLog.Core.UnitTests
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()},Message={message}," +
                 $"{details.Key.Name}={details.Value}," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Fatal(operation, status, message, ex, details);
 
@@ -584,7 +584,7 @@ namespace NuciLog.Core.UnitTests
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()},Message={message}," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Fatal(operation, status, message, ex, details);
 
@@ -605,7 +605,7 @@ namespace NuciLog.Core.UnitTests
             string expectedLogLine =
                 $"Operation={operation.Name},OperationStatus={status.Name.ToUpper()},Message={message}," +
                 $"{TestLogInfoKey.TestKey.Name}=teeest,{TestLogInfoKey.TestKey2.Name}=teeest2," +
-                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace={ex.StackTrace}";
+                $"Exception={ex.GetType()},ExceptionMessage={ex.Message},StackTrace=<NULL>";
             
             logger.Fatal(operation, status, message, ex, details, details2);
 


### PR DESCRIPTION
 - Merge duplicated log infos into one
 - Handle cases where the log info value is either null or empty
 - Apply the formatting only when it's actually needed for writing the output (1)

(1) This means that the formatting will not actually be applied when the logging is disabled for that message